### PR TITLE
MVP of player creation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -25,6 +25,7 @@
     "no-console": "off",
     "no-process-env": "off",
     "no-sync": "off",
+    "no-undefined": "off",
     "tsdoc/syntax": "warn",
     "valid-jsdoc": "off"
   },

--- a/src/lib/auth/creation.ts
+++ b/src/lib/auth/creation.ts
@@ -1,5 +1,8 @@
 import Player from '../base/player';
 import { InputHandler } from '../interfaces';
+import { PlayerCreationState, PlayerLoginState } from './enums';
+import { checkPassword } from './passwords';
+import { PlayerGameplayState } from '../base/enums';
 
 export default class PlayerCreation implements InputHandler {
   private static instance: PlayerCreation;
@@ -14,18 +17,59 @@ export default class PlayerCreation implements InputHandler {
   }
 
   handleInput(player: Player, data: string): void {
-    player.sendData(data);
+    data = data.replace(/\r?\n|\r/g, '');
+    switch (player.creationState) {
+      case PlayerCreationState.PASSWORD:
+        this.handlePassword(player, data);
+        break;
+      case PlayerCreationState.PASSWORD_VERIFY:
+        this.handlePasswordVerify(player, data);
+        break;
+      case PlayerCreationState.DISPLAY_NAME:
+        this.handleDisplayName(player, data);
+        break;
+      default:
+        throw new Error('Unexpected player creation state.');
+    }
   }
 
   private handlePassword(player: Player, data: string): void {
-    data = data.replace(/\r?\n|\r/g, '');
     if (data.length < 8) {  // FIXME: We should do a bit more checking than this
-      player.sendData("That password doesn't look too terribly secure.\r\nCare to try another? ");
+      player.sendData("\r\nThat password doesn't look too terribly secure.\r\nCare to try another? ");
+      player.setEcho(false);
     } else {
       player.password = data;
-      player.sendData("Great! Now that we've got that out of the way, how would you like others to see your name? ");
-      player.sendData(`Enter here, or press enter to accept default [${player.username}]: `);
+      player.creationState = PlayerCreationState.PASSWORD_VERIFY;
+      player.sendData('\r\nPerfect! Now, can you type that for me again to confirm? ');
       player.setEcho(false);
     }
+  }
+
+  private handlePasswordVerify(player: Player, data: string): void {
+    if (checkPassword(data, <string>player.playerData.password)) {
+      player.creationState = PlayerCreationState.DISPLAY_NAME;
+      player.sendData("\r\nGreat! Now that we've got that out of the way, how would you like others to see your name?\r\n");
+      player.sendData(`Enter here, or press enter to accept default [${player.username}]: `);
+      player.setEcho(true);
+    } else {
+      player.creationState = PlayerCreationState.PASSWORD;
+      player.sendData("\r\nUnfortunately, those did not match. Let's try that again.\r\n");
+      player.sendData('What would you like for a password? ');
+      player.setEcho(false);
+    }
+  }
+
+  private handleDisplayName(player: Player, data: string): void {
+    player.sendData(`Great! Other players will see you as ${data} now.\r\n`);
+    player.displayName = data;
+    this.finishCreation(player);
+  }
+
+  private finishCreation(player: Player): void {
+    player.sendData('Enjoy the game!\r\n');
+    player.loginState = PlayerLoginState.LOGGED_IN;
+    player.creationState = PlayerCreationState.DONE;
+    player.gameplayState = PlayerGameplayState.PLAYING;
+    player.save();
   }
 }

--- a/src/lib/auth/creation.ts
+++ b/src/lib/auth/creation.ts
@@ -6,8 +6,6 @@ import { PlayerGameplayState } from '../base/enums';
 
 export default class PlayerCreation implements InputHandler {
   private static instance: PlayerCreation;
-  // This can be used for temporary storage of data during creation
-  private static playerData: Record<string, unknown> = {};
 
   private constructor() { }  // eslint-disable-line
 

--- a/src/lib/auth/creation.ts
+++ b/src/lib/auth/creation.ts
@@ -3,6 +3,7 @@ import { InputHandler } from '../interfaces';
 
 export default class PlayerCreation implements InputHandler {
   private static instance: PlayerCreation;
+  // This can be used for temporary storage of data during creation
   private static playerData: Record<string, unknown> = {};
 
   private constructor() { }  // eslint-disable-line
@@ -14,5 +15,17 @@ export default class PlayerCreation implements InputHandler {
 
   handleInput(player: Player, data: string): void {
     player.sendData(data);
+  }
+
+  private handlePassword(player: Player, data: string): void {
+    data = data.replace(/\r?\n|\r/g, '');
+    if (data.length < 8) {  // FIXME: We should do a bit more checking than this
+      player.sendData("That password doesn't look too terribly secure.\r\nCare to try another? ");
+    } else {
+      player.password = data;
+      player.sendData("Great! Now that we've got that out of the way, how would you like others to see your name? ");
+      player.sendData(`Enter here, or press enter to accept default [${player.username}]: `);
+      player.setEcho(false);
+    }
   }
 }

--- a/src/lib/auth/creation.ts
+++ b/src/lib/auth/creation.ts
@@ -58,6 +58,7 @@ export default class PlayerCreation implements InputHandler {
   }
 
   private handleDisplayName(player: Player, data: string): void {
+    if (data.trim() === '') data = player.username;
     player.sendData(`Great! Other players will see you as ${data} now.\r\n`);
     player.displayName = data;
     this.finishCreation(player);

--- a/src/lib/auth/enums.ts
+++ b/src/lib/auth/enums.ts
@@ -1,0 +1,19 @@
+/**
+ * Enum for where the player is in the login process
+ */
+export enum PlayerLoginState {
+  USERNAME,
+  PASSWORD,
+  CREATION,
+  LOGGED_IN
+}
+
+/**
+ * Enum to track a user through the player creation process
+ */
+export enum PlayerCreationState {
+  PASSWORD,
+  PASSWORD_VERIFY,
+  DISPLAY_NAME,
+  DONE
+}

--- a/src/lib/auth/login.ts
+++ b/src/lib/auth/login.ts
@@ -15,10 +15,15 @@ export default class Login implements InputHandler {
   }
 
   handleInput(player: Player, data: string): void {
-    if (player.loginState === PlayerLoginState.USERNAME) {
-      this.handleUsername(player, data);
-    } else if (player.loginState === PlayerLoginState.PASSWORD) {
-      this.handlePassword(player, data);
+    switch (player.loginState) {
+      case PlayerLoginState.USERNAME:
+        this.handleUsername(player, data);
+        break;
+      case PlayerLoginState.PASSWORD:
+        this.handlePassword(player, data);
+        break;
+      default:
+        throw new Error('Unexpected player login state.');
     }
   }
 

--- a/src/lib/auth/login.ts
+++ b/src/lib/auth/login.ts
@@ -1,6 +1,8 @@
 import Player from '../base/player';
 import { checkPassword } from './passwords';
 import { InputHandler } from '../interfaces';
+import { PlayerLoginState } from './enums';
+import { PlayerGameplayState } from '../base/enums';
 
 export default class Login implements InputHandler {
   private static instance: Login;
@@ -13,9 +15,9 @@ export default class Login implements InputHandler {
   }
 
   handleInput(player: Player, data: string): void {
-    if (player.username === null) {
+    if (player.loginState === PlayerLoginState.USERNAME) {
       this.handleUsername(player, data);
-    } else {
+    } else if (player.loginState === PlayerLoginState.PASSWORD) {
       this.handlePassword(player, data);
     }
   }
@@ -24,10 +26,13 @@ export default class Login implements InputHandler {
     data = data.trim().toLowerCase();
     player.username = data;
     if (!player.exists()) {
+      player.loginState = PlayerLoginState.CREATION;
+      player.gameplayState = PlayerGameplayState.CREATION;
       player.sendData("Haven't seen you around here before.\r\n");
       player.sendData('What would you like for a password? ');
       player.setEcho(false);
     } else {
+      player.loginState = PlayerLoginState.PASSWORD;
       player.sendData('Welcome back!\r\nWhat... is your password? ');
       player.setEcho(false);
     }
@@ -42,6 +47,8 @@ export default class Login implements InputHandler {
       player.password = data;
       player.sendData(`\r\nWelcome, ${player}!\r\n`);
       player.setEcho(true);
+      player.loginState = PlayerLoginState.LOGGED_IN;
+      player.gameplayState = PlayerGameplayState.PLAYING;
     } else {
       player.sendData("\r\nWell that's just not right. Care to try again? ");
       player.setEcho(false);

--- a/src/lib/base/enums.ts
+++ b/src/lib/base/enums.ts
@@ -13,8 +13,17 @@ export enum ObjectType {
  * Enum for the state of the main game engine
  */
 export enum GameState {
-  STARTING = 1,
-  RUNNING = 2,
-  SHUTTING_DOWN = 3,
-  SHUTDOWN = 4
+  STARTING,
+  RUNNING,
+  SHUTTING_DOWN,
+  SHUTDOWN
+}
+
+/**
+ * Enum for what the player is currently doing and how to handle their input
+ */
+export enum PlayerGameplayState {
+  LOGIN,
+  CREATION,
+  PLAYING
 }

--- a/src/lib/base/player.ts
+++ b/src/lib/base/player.ts
@@ -4,13 +4,14 @@ import * as path from 'path';
 import { TelnetSocket } from 'telnet-socket';
 
 import Living from './living';
-import { ObjectType } from './enums';
+import { ObjectType, PlayerGameplayState } from './enums';
 import PlayerCreation from '../auth/creation';
 import Login from '../auth/login';
 import { makePassword } from '../auth/passwords';
 import Game from '../game';
 import { InputHandler } from '../interfaces';
 import Config from '../../config';
+import { PlayerLoginState } from '../auth/enums';
 
 /**
  * A class representing a player character
@@ -20,9 +21,10 @@ export default class Player extends Living {
   private _socket: TelnetSocket = null;
   private _inputBuffer: Array<string> = [];
   private _outputBuffer: Array<string> = [];
-  private _username: string = null;
-  private _password: string = null;  // This will be encrypted.
-  private _playerData: Record<string, unknown> = null;
+  private _playerData: Record<string, unknown> = {};
+
+  loginState: PlayerLoginState = PlayerLoginState.USERNAME;
+  gameplayState: PlayerGameplayState = PlayerGameplayState.LOGIN;
 
   constructor(socket: TelnetSocket = null) {
     super();
@@ -34,19 +36,22 @@ export default class Player extends Living {
   }
 
   get loggedIn(): boolean {
-    return (this._username !== null && this._password !== null && this.playerData !== null);
+    return this.gameplayState === PlayerGameplayState.PLAYING;
   }
 
   get inputHandler(): InputHandler {
-    if (!this.loggedIn) {
-      if (this._username === null || this._password === null) {
-        console.debug('[debug] Sending input to login daemon.');
+    switch (this.gameplayState) {
+      case PlayerGameplayState.LOGIN:
+        console.debug('[debug] Sending input to the login daemon.');
         return Login.getInstance();
-      }
-      console.debug('[debug] Sending input to creation daemon.');
-      return PlayerCreation.getInstance();
+      case PlayerGameplayState.CREATION:
+        console.debug('[debug] Sending input to the player creation daemon.');
+        return PlayerCreation.getInstance();
+      case PlayerGameplayState.PLAYING:  // Fall through to the default handler
+      default:
+        console.debug('[debug] Echoing player input.');
+        return { handleInput: (player: Player, msg: string) => Game.getInstance().broadcast(msg) };
     }
-    return { handleInput: (player: Player, msg: string) => Game.getInstance().broadcast(msg) };
   }
 
   setEcho(echo: boolean): void {
@@ -64,19 +69,19 @@ export default class Player extends Living {
   }
 
   set username(username: string) {
-    if (this._username !== null) {
+    if (this._playerData.username !== undefined) {
       throw new Error('Cannot set username after user is already logged in.');
     } else {
-      this._username = username;
+      this._playerData.username = username;
     }
   }
 
-  get username(): string {
-    return this._username;
+  get username(): string | undefined {
+    return this._playerData ? <string>this._playerData.username : undefined;
   }
 
   get displayName(): string {
-    return this.playerData ? this.playerData.display_name as string : this.username;
+    return this.playerData ? <string>this.playerData.display_name : this.username;
   }
 
   get savePath(): string {
@@ -85,7 +90,7 @@ export default class Player extends Living {
   }
 
   set password(password: string) {
-    this._password = makePassword(password);
+    this._playerData.password = makePassword(password);
   }
 
   /**

--- a/test/lib/auth/creation.spec.ts
+++ b/test/lib/auth/creation.spec.ts
@@ -1,15 +1,161 @@
+// @ts-nocheck
+
 import assume from 'assume';
+import { Socket } from 'net';
+import sinon from 'sinon';
+import { TelnetSocket } from 'telnet-socket';
+
 import PlayerCreation from '../../../src/lib/auth/creation';
+import Player from '../../../src/lib/base/player';
+import { PlayerGameplayState } from '../../../src/lib/base/enums';
+import { PlayerCreationState, PlayerLoginState } from '../../../src/lib/auth/enums';
+import * as passwords from '../../../src/lib/auth/passwords';
 
 describe('Player Creation', () => {
-  let creation: PlayerCreation;
+  let creation: PlayerCreation, player: Player;
+  const goodPassword = 'Dnxq2_2!', badPassword = 'foo';
 
   before(() => {
     creation = PlayerCreation.getInstance();
+    sinon.stub(console, 'debug');
+    sinon.stub(console, 'error');
+    sinon.stub(passwords, 'checkPassword').returns(true);
+    sinon.stub(passwords, 'makePassword');
+  });
+
+  after(() => {
+    console.debug.restore();
+    console.error.restore();
+    passwords.checkPassword.restore();
+    passwords.makePassword.restore();
+  });
+
+  beforeEach(() => {
+    player = new Player(new TelnetSocket(new Socket()));
+    player.username = 'zaphod_beeblebrox';
+    player.gameplayState = PlayerGameplayState.CREATION;
+    sinon.stub(player, 'sendData');
+    sinon.stub(player._socket, 'will').get(() => { return { echo: sinon.stub() }; });
+    sinon.stub(player._socket, 'wont').get(() => { return { echo: sinon.stub() }; });
   });
 
   it('is a singleton', () => {
     const creation2 = PlayerCreation.getInstance();
     assume(creation).equals(creation2);
+  });
+
+  describe('password input', () => {
+    it('asks the player to verify their password', () => {
+      creation.handleInput(player, goodPassword);
+      assume(
+        player.sendData.firstCall.calledWithExactly(
+          '\r\nPerfect! Now, can you type that for me again to confirm? '
+        )
+      ).is.true();
+    });
+
+    it('bumps the player to the verify password step', () => {
+      creation.handleInput(player, goodPassword);
+      assume(player.creationState).equals(PlayerCreationState.PASSWORD_VERIFY);
+    });
+
+    it('rejects short passwords', () => {
+      creation.handleInput(player, badPassword);
+      assume(
+        player.sendData.firstCall.calledWithExactly(
+          "\r\nThat password doesn't look too terribly secure.\r\nCare to try another? "
+        )
+      ).is.true();
+    });
+
+    it('keeps the player at password input if the password was bad', () => {
+      creation.handleInput(player, badPassword);
+      assume(player.creationState).equals(PlayerCreationState.PASSWORD);
+    });
+  });
+
+  describe('verify password', () => {
+    it('asks the player for a display name if passwords match', () => {
+      creation.handleInput(player, goodPassword);
+      creation.handleInput(player, goodPassword);
+      assume(
+        player.sendData.secondCall.calledWithExactly(
+          "\r\nGreat! Now that we've got that out of the way, how would you like others to see your name?\r\n"
+        )
+      ).is.true();
+    });
+
+    it('bumps the player to the display name step', () => {
+      creation.handleInput(player, goodPassword);
+      creation.handleInput(player, goodPassword);
+      assume(player.creationState).equals(PlayerCreationState.DISPLAY_NAME);
+    });
+
+    it('rejects non-matching passwords', () => {
+      passwords.checkPassword.returns(false);
+      creation.handleInput(player, goodPassword);
+      creation.handleInput(player, badPassword);
+      assume(
+        player.sendData.secondCall.calledWithExactly(
+          "\r\nUnfortunately, those did not match. Let's try that again.\r\n"
+        )
+      ).is.true();
+      passwords.checkPassword.returns(true);
+    });
+
+    it("resets the player to password input if the passwords didn't match", () => {
+      passwords.checkPassword.returns(false);
+      creation.handleInput(player, goodPassword);
+      creation.handleInput(player, badPassword);
+      assume(player.creationState).equals(PlayerCreationState.PASSWORD);
+      passwords.checkPassword.returns(true);
+    });
+  });
+
+  describe('display name', () => {
+    it("confirms the player's display name", () => {
+      creation.handleInput(player, goodPassword);
+      creation.handleInput(player, goodPassword);
+      creation.handleInput(player, 'Zaphod Beeblebrox');
+      assume(player.sendData.getCall(4).calledWithExactly(
+        'Great! Other players will see you as Zaphod Beeblebrox now.\r\n'
+      ));
+    });
+
+    it("sets the player's display name as specified", () => {
+      creation.handleInput(player, goodPassword);
+      creation.handleInput(player, goodPassword);
+      creation.handleInput(player, 'Zaphod Beeblebrox');
+      assume(player.displayName).equals('Zaphod Beeblebrox');
+    });
+
+    it("users the player's username by default", () => {
+      creation.handleInput(player, goodPassword);
+      creation.handleInput(player, goodPassword);
+      creation.handleInput(player, '');
+      assume(player.displayName).equals('zaphod_beeblebrox');
+    });
+  });
+
+  describe('finalizing', () => {
+    it('welcomes the player', () => {
+      creation.finishCreation(player);
+      assume(player.sendData.firstCall.calledWithExactly('Enjoy the game!\r\n'));
+    });
+
+    it('sets the player to logged in', () => {
+      creation.finishCreation(player);
+      assume(player.loginState).equals(PlayerLoginState.LOGGED_IN);
+    });
+
+    it('sets the player to done with creation', () => {
+      creation.finishCreation(player);
+      assume(player.creationState).equals(PlayerCreationState.DONE);
+    });
+
+    it('sets the player to playing', () => {
+      creation.finishCreation(player);
+      assume(player.gameplayState).equals(PlayerGameplayState.PLAYING);
+    });
   });
 });

--- a/test/lib/auth/login.spec.ts
+++ b/test/lib/auth/login.spec.ts
@@ -22,6 +22,14 @@ describe('Login', () => {
     config = Config.getInstance();
     config.loadConfig();
     logind = Login.getInstance();
+    sinon.stub(console, 'debug');
+    sinon.stub(console, 'error');
+  });
+
+  after(() => {
+    restore();
+    console.debug.restore();
+    console.error.restore();
   });
 
   beforeEach(() => {
@@ -31,10 +39,6 @@ describe('Login', () => {
   it('is a singleton', () => {
     const logind2 = Login.getInstance();
     assume(logind).equals(logind2);
-  });
-
-  after(() => {
-    restore();
   });
 
   describe('handleInput', () => {
@@ -74,7 +78,7 @@ describe('Login', () => {
 
     it("checks the user's password if they exist", () => {
       sinon.stub(passwords, 'checkPassword').returns(true);
-      player.username = 'zaphod';
+      logind.handleInput(player, 'zaphod');
       logind.handleInput(player, 'foobar');
       assume(passwords.checkPassword.calledOnce).is.true();
       passwords.checkPassword.restore();
@@ -83,10 +87,10 @@ describe('Login', () => {
     it('welcomes the player if their password is correct', () => {
       sinon.stub(passwords, 'checkPassword').returns(true);
       sinon.stub(player, 'sendData');
-      player.username = 'zaphod';
+      logind.handleInput(player, 'zaphod');
       logind.handleInput(player, 'foobar');
       assume(
-        player.sendData.firstCall.calledWithExactly(
+        player.sendData.secondCall.calledWithExactly(
           '\r\nWelcome, Zaphod Beeblebrox!\r\n'
         )
       ).is.true();
@@ -96,7 +100,7 @@ describe('Login', () => {
     it('re-asks for a password if it was incorrect', () => {
       sinon.stub(passwords, 'checkPassword').returns(false);
       sinon.stub(player, 'sendData');
-      player.username = 'zaphod';
+      logind.handleInput(player, 'zaphod');
       logind.handleInput(player, 'foobar');
       assume(
         player.sendData.firstCall.calledWithExactly(

--- a/test/lib/auth/login.spec.ts
+++ b/test/lib/auth/login.spec.ts
@@ -78,14 +78,17 @@ describe('Login', () => {
 
     it("checks the user's password if they exist", () => {
       sinon.stub(passwords, 'checkPassword').returns(true);
+      sinon.stub(passwords, 'makePassword');
       logind.handleInput(player, 'zaphod');
       logind.handleInput(player, 'foobar');
       assume(passwords.checkPassword.calledOnce).is.true();
       passwords.checkPassword.restore();
+      passwords.makePassword.restore();
     });
 
     it('welcomes the player if their password is correct', () => {
       sinon.stub(passwords, 'checkPassword').returns(true);
+      sinon.stub(passwords, 'makePassword');
       sinon.stub(player, 'sendData');
       logind.handleInput(player, 'zaphod');
       logind.handleInput(player, 'foobar');
@@ -95,6 +98,7 @@ describe('Login', () => {
         )
       ).is.true();
       passwords.checkPassword.restore();
+      passwords.makePassword.restore();
     });
 
     it('re-asks for a password if it was incorrect', () => {

--- a/test/lib/game.spec.ts
+++ b/test/lib/game.spec.ts
@@ -9,6 +9,16 @@ import Player from '../../src/lib/base/player';
 describe('Game', () => {
   let game: Game;
 
+  before(() => {
+    sinon.stub(console, 'debug');
+    sinon.stub(console, 'error');
+  });
+
+  after(() => {
+    console.debug.restore();
+    console.error.restore();
+  });
+
   beforeEach(() => {
     Game.instance = null;
     game = Game.getInstance();

--- a/test/lib/server.spec.ts
+++ b/test/lib/server.spec.ts
@@ -9,6 +9,16 @@ import sinon from 'sinon';
 describe('Server', () => {
   let server: Server;
 
+  before(() => {
+    sinon.stub(console, 'debug');
+    sinon.stub(console, 'error');
+  });
+
+  after(() => {
+    console.debug.restore();
+    console.error.restore();
+  });
+
   beforeEach(() => {
     server = new Server({ port: 0 });
     server._game = Game.getInstance();


### PR DESCRIPTION
Players are now able to create themselves! Yay!

With input from @DaftPun, I changed to using enums for handling player state as opposed to janky "okay so if the user has a username, and a password, but they haven't yet set..." yadda yadda nonsense. So that's actually all handled very elegantly now. And it is FAR more bomb proof.

Tests are still broken, because SO much changed. But I think the resulting tests after this will actually be much more useful.