### PR TITLE
Handle client disconnections

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,8 @@
     "no-sync": "off",
     "no-undefined": "off",
     "tsdoc/syntax": "warn",
-    "valid-jsdoc": "off"
+    "valid-jsdoc": "off",
+    "max-nested-callbacks": "off"
   },
   "overrides": [
     {

--- a/src/lib/game.ts
+++ b/src/lib/game.ts
@@ -24,6 +24,13 @@ export default class Game {
     return this;
   }
 
+  removePlayer(player: Player): Game {
+    if (this._players.includes(player)) {
+      this._players.splice(this._players.indexOf(player), 1);
+    }
+    return this;
+  }
+
   get players(): Array<Player> { return this._players; }
 
   async gameLoop(): Promise<void> {


### PR DESCRIPTION
Fixes #7

Player disconnections are now gracefully handled, with their disconnection broadcast and then removing them from the game.

I also did a small bit of rearrangement of some of the test suites to use nested `describe`s, for a slightly cleaner output.